### PR TITLE
Update dependencies to .NET 8

### DIFF
--- a/HelpersLib/HelpersLib.csproj
+++ b/HelpersLib/HelpersLib.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/UploaderX-cli/UploaderX-cli.csproj
+++ b/UploaderX-cli/UploaderX-cli.csproj
@@ -14,7 +14,7 @@
     <ExternalConsole>true</ExternalConsole>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
   <ItemGroup>

--- a/UploaderX-maui/UploaderX-maui.csproj
+++ b/UploaderX-maui/UploaderX-maui.csproj
@@ -52,7 +52,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- bump package versions to latest 8.x

## Testing
- `dotnet build UploaderX.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2591570832493aae1b00abfbc7d